### PR TITLE
passing in type from query params into render (index route)

### DIFF
--- a/controllers/products.js
+++ b/controllers/products.js
@@ -11,16 +11,17 @@ const { Products } = require("../models");
 router.get("/", async (req, res, next) => {
     try {
         let products;
+        let type = "";
         if ((typeof req.query.type === "undefined")||(req.query.type==="")){
             products = await Products.find({});
         } else {
-            let type = req.query.type;
+            type = req.query.type;
             type = type[0].toUpperCase()+type.slice(1,type.length);
             // type = type.charAt(0).toUpperCase()+type.slice(1);
             // console.log(type);
             products = await Products.find({productType:type});
         }
-        res.render("products/index", { products })
+        res.render("products/index", { products,type })
     } catch (error) {
         console.log(error);
         res.send(error);


### PR DESCRIPTION
Controller will pass in variable `type` into index ejs rendering.
`type` will either hold `""` (empty string) or the product type string (e.g. `book` or `game`) as its value.

Feel free to review changes in code for more info.